### PR TITLE
Clean up fields in schema

### DIFF
--- a/nipc-openapi/NIPC_REST.yaml
+++ b/nipc-openapi/NIPC_REST.yaml
@@ -2085,12 +2085,8 @@ components:
               format: uuid
               example: 12345678-1234-5678-1234-56789abcdef4
             long:
-              type: string
-              format: boolean
-              example: no
-              enum:
-                - yes # attribute is of type long
-                - no # attrribute is of type normal, default
+              type: boolean
+              example: false
       xml:
         name: BLEAttributes
 
@@ -2396,12 +2392,8 @@ components:
               description: |-
                 If we can cache information, then device doesn't need
                 to be rediscovered before every connected.
-              type: string
-              format: boolean
-              example: no
-              enum:
-                - no #  default
-                - yes
+              type: boolean
+              default: false
             cacheIdlePurge:
               description: cache expiry period, when device allows
               type: integer
@@ -2409,12 +2401,8 @@ components:
             autoUpdate:
               description: |-
                 autoupdate services if device supports it (default)
-              type: string
-              format: boolean
-              example: yes
-              enum:
-                - yes
-                - no
+              type: boolean
+              example: true
           xml:
             name: ble
       xml:
@@ -2465,12 +2453,8 @@ components:
           example: 0001
         forcedResponse:
           description: do or do not wait for a response?
-          type: string
-          format: boolean
-          example: yes
-          enum:
-            - yes
-            - no
+          type: boolean
+          example: true
       xml:
         name: AttributeValue
         
@@ -2489,12 +2473,8 @@ components:
           type: integer
         forcedResponse:
           description: do or do not wait for a response?
-          type: string
-          format: boolean
-          example: yes
-          enum:
-            - yes
-            - no
+          type: boolean
+          example: true
       xml:
         name: AttributeFile
         
@@ -2513,12 +2493,8 @@ components:
           type: integer
         forcedResponse:
           description: do or do not wait for a response?
-          type: string
-          format: boolean
-          example: yes
-          enum:
-            - yes
-            - no
+          type: boolean
+          example: true
       xml:
         name: AttributeFile
         
@@ -2573,22 +2549,15 @@ components:
             - timestamped
             - payload
         replay:
-          type: string
-          format: boolean
-          example: no
-          enum:
-            - no #default
-            - yes
-        forced_ack:
+          type: boolean
+          example: false
+          default: false
+        forcedAck:
           description: |-
             When not looking at device/attribute support MUST we
             ackhnowledge?
-          type: string
-          format: boolean
-          example: yes
-          enum:
-            - yes
-            - no
+          type: boolean
+          example: true
       xml:
         name: Subscription
 
@@ -2758,12 +2727,9 @@ components:
         autoDisconnect:
           description: |- 
             do we automatically disconnect after a RESTful operation?
-          type: string
-          format: boolean
-          example: no
-          enum:
-            - no
-            - yes # default
+          type: boolean
+          example: true
+          default: true
         operations:
           type: array
           xml:

--- a/nipc-openapi/NIPC_REST.yaml
+++ b/nipc-openapi/NIPC_REST.yaml
@@ -2510,12 +2510,12 @@ components:
           type: string
           format: byte
           example: 0001
-        maxtime:
+        maxTime:
           description: |-
             maximum time the conditional read should run in seconds 
             (default 10 sec, max 60 sec) 
           type: integer
-        maxrepeat: 
+        maxRepeat: 
           description: |-
            maximum time the conditional read should repeat 
            (default 5, max 60) 


### PR DESCRIPTION
This PR contains the following changes: 
1. Changed some of the fields that had type=string and format=boolean to use type=boolean. 
The boolean works better when these APIs need to be consumed by SDKs since there is a direct data type that is available instead of using arbitrary strings. 
Also, added default values for some of them. 
3. Renamed some fields to be consistent with others