### PR TITLE
Bbrinckm draft01

### DIFF
--- a/nipc-openapi/NIPC_REST.yaml
+++ b/nipc-openapi/NIPC_REST.yaml
@@ -2824,7 +2824,7 @@ components:
       allOf:
         - type: object
           properties:
-            operation:
+            path:
               type: string
               enum:
                - /connectivity/connection

--- a/nipc-openapi/NIPC_REST.yaml
+++ b/nipc-openapi/NIPC_REST.yaml
@@ -2860,7 +2860,7 @@ components:
               POST /data/attribute:
                 '#/components/schemas/AttributeValue'
               DELETE /data/attribute:
-                '#/components/schema/Attribute'
+                '#/components/schemas/Attribute'
               GET /data/attribute:
                 '#/components/schemas/Attribute'
               POST /data/attribute/Subscription:

--- a/nipc-openapi/NIPC_REST.yaml
+++ b/nipc-openapi/NIPC_REST.yaml
@@ -28,7 +28,7 @@ info:
   license:
     name: TBD
     url: TBD
-  version: 0.6.0
+  version: 0.6.1
 externalDocs:
   description: NIPC IETF draft
   url: TBD
@@ -102,7 +102,7 @@ paths:
           in: query
           description: device or group id that need to be filtered
           required: false
-          explode: true
+          explode: false
           schema:
             type: string
             format: uuid
@@ -142,7 +142,7 @@ paths:
           in: query
           description: device or group id that need to be filtered
           required: false
-          explode: true
+          explode: false
           schema:
             type: string
             format: uuid
@@ -336,7 +336,7 @@ paths:
           in: query
           description: device or group ids that need to be filtered
           required: false
-          explode: true
+          explode: false
           schema:
             type: string
             format: uuid
@@ -375,7 +375,7 @@ paths:
           in: query
           description: device or group ids that need to be filtered
           required: false
-          explode: true
+          explode: false
           schema:
             type: string
             format: uuid
@@ -557,7 +557,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
 
-  /connectivity/services/selective:
+  /connectivity/services/discover:
     post:
       tags:
         - connectivity
@@ -568,6 +568,7 @@ paths:
         Selectively discover services on a device, limited 
         to services described in the parameters.
         Group ids will fail.
+      operationId: GetSelectiveServices
       requestBody:
         content:
           application/json:
@@ -2660,7 +2661,7 @@ components:
 ## A subscription attribute of an Device
     SubscriptionRaw:
       allOf:
-        - $ref: '#/components/schemas/Attribute'
+        - $ref: '#/components/schemas/AttributeRaw'
       type: object
       properties:
         forcedAck:
@@ -3154,7 +3155,7 @@ components:
               GET /connectivity/connection:
                 '#/components/schemas/SuccessResponse'
               POST /data/attribute:
-                '#/components/schemas/RegisteredAttributeValue'
+                '#/components/schemas/AttributeValueResponse'
               DELETE /data/attribute:
                 '#/components/schemas/AttributeValueResponse'
               GET /data/attribute:

--- a/nipc-openapi/NIPC_REST.yaml
+++ b/nipc-openapi/NIPC_REST.yaml
@@ -28,7 +28,7 @@ info:
   license:
     name: TBD
     url: TBD
-  version: 0.5.5
+  version: 0.6.0
 externalDocs:
   description: NIPC IETF draft
   url: TBD
@@ -100,7 +100,7 @@ paths:
       parameters:
         - name: id
           in: query
-          description: device ids that need to be filtered
+          description: device or group id that need to be filtered
           required: false
           explode: true
           schema:
@@ -140,7 +140,7 @@ paths:
       parameters:
         - name: id
           in: query
-          description: device or group ids that need to be filtered
+          description: device or group id that need to be filtered
           required: false
           explode: true
           schema:
@@ -176,12 +176,12 @@ paths:
         support binding) 
       description: |-
         Create a binding for a device id, will fail if device has
-        multiple technologies defined 
+        multiple technologies defined, group ids will also fail
       operationId: CreateBindingbyID
       parameters:
         - name: id
           in: path
-          description: device or group ids that need to be filtered
+          description: device id that need to be filtered
           required: true
           schema:
             type: string
@@ -214,7 +214,7 @@ paths:
       summary: Get binding by id for a device
       description: |-
         Get binding by id for a device, success when binding found,
-        failure when no binding 
+        failure when no binding, group ids will fail 
       operationId: GetBindingbyId
       parameters:
         - name: id
@@ -250,7 +250,8 @@ paths:
       tags:
         - connectivity
       summary: Delete binding by id for a device
-      description: Delete binding by id for a device
+      description: |-
+        Delete binding by id for a device, group ids will fail
       operationId: DeleteBindingbyID
       parameters:
         - name: id
@@ -407,14 +408,14 @@ paths:
         Connect a device by device id (device technology needs to
         support connection) 
       description: |-
-        Connect a device by device id, Serivce discovery not
-        supported, will fail if device has multiple technologies
-        defined.
+        Connect a device by device id, full service discovery 
+        will be performed. Will fail if device has multiple 
+        technologies defined. Group ids will fail.
       operationId: CreateConnectionbyID
       parameters:
         - name: id
           in: path
-          description: device or group ids that need to be filtered
+          description: device id that need to be filtered
           required: true
           schema:
             type: string
@@ -446,12 +447,13 @@ paths:
       summary: Get connection by id for a device
       description: |-
         Get connection by id for a device, success when device
-        connected, failure when device not connected 
+        connected, failure when device not connected.
+        Group ids will also fail. 
       operationId: GetConnectionbyId
       parameters:
         - name: id
           in: path
-          description: device or group ids that need to be filtered
+          description: device id that need to be filtered
           required: true
           schema:
             type: string
@@ -481,12 +483,15 @@ paths:
       tags:
         - connectivity
       summary: Delete connection by id for a device
-      description: Disconnect a device by id
+      description: |-
+        Disconnect a device by id, success when device
+        is disconnected, failure disconnect fails.
+        Group ids will also fail. 
       operationId: DeleteConnectionbyID
       parameters:
         - name: id
           in: path
-          description: device or group ids that need to be filtered
+          description: device id that need to be filtered
           required: true
           schema:
             type: string
@@ -512,53 +517,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
   
-  /connectivity/services:
+  /connectivity/services/{id}:            
     get:
       tags:
         - connectivity
-      summary: Discover services on a device
-      description: Discover services on a device
-      operationId: ServiceDiscovey
-      parameters:
-      - name: Service
-        in: query
-        description: Services to discover
-        required: true
-        schema:
-          $ref: '#/components/schemas/Service'
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ServiceResponse'          
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-                
-  /connectivity/services/id/{id}:            
-    get:
-      tags:
-        - connectivity
-      summary: Get services by id for a device
+      summary: Get all services by id for a device
       description: |-
-        Get services by id for a connected device, success when
-        device connected, failure when device not connected 
+        Get all services by id for a connected device, success
+        when service discovery succeeds failure, failure when 
+        Service discovery fails. This updates cache for cached
+        Services. Fails when using a group id.
       operationId: GetServicesbyId
       parameters:
         - name: id
           in: path
-          description: device or group ids that need to be filtered
+          description: device id that need to be filtered
           required: true
           schema:
             type: string
@@ -583,6 +556,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
+
+  /connectivity/services/selective:
+    post:
+      tags:
+        - connectivity
+      summary: |-
+        Selectively discover services on a device, limited 
+        to services described in the parameters
+      description: |-
+        Selectively discover services on a device, limited 
+        to services described in the parameters.
+        Group ids will fail.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Service'
+        required: true    
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceResponse'          
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '405':
+          description: Invalid request
+        '500':
+          description: Server-side failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
 
 ### Data
   /data/attribute:
@@ -650,6 +660,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
   
+  /data/attribute/{id}/{attributename}:
     delete:
       tags:
         - data
@@ -657,12 +668,22 @@ paths:
       description: Delete a value to an attribute on a device
       operationId: dataDelete
       parameters:
-      - name: attribute
-        in: query
-        description: attributes of a given device
+      - name: id
+        in: path
+        description: device id that need to be filtered
         required: true
         schema:
-          $ref: '#/components/schemas/Attribute'
+          type: string
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
+      - name: attributename
+        in: path
+        description: attribute name that needs to be filtered
+        required: true
+        explode: true
+        schema:
+          type: string
+          example: "temperature"
       responses:
         '200':
           description: Success
@@ -690,12 +711,22 @@ paths:
       description: Read a value to an attribute on a device
       operationId: dataRead
       parameters:
-      - name: attribute
-        in: query
-        description: attributes of a given device
+      - name: id
+        in: path
+        description: device id that need to be filtered
         required: true
         schema:
-          $ref: '#/components/schemas/Attribute'
+          type: string
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
+      - name: attributename
+        in: path
+        description: attribute name that needs to be filtered
+        required: true
+        explode: true
+        schema:
+          type: string
+          example: "temperature"
       responses:
         '200':
           description: Success
@@ -715,8 +746,80 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
+
+  /data/attribute/write:
+    post:
+      tags:
+        - data
+      summary: Write a value to an attribute using technology extensions
+      description: |-
+        Write a value to an attribute directly, addressing the attribute
+        with technology-specific extensions, this does not require
+        attribute registration. You cannot write to a group id.
+      operationId: dataAttrWrite
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AttributeValueRaw'
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttributeValueResponseRaw'
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '405':
+          description: Invalid request
+        '500':
+          description: Server-side failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
+                
+  /data/attribute/read:
+    post:
+      tags:
+        - data
+      summary: Read a value to an attribute using technology extensions
+      description: |-
+        Read a value to an attribute directly, addressing the attribute
+        with technology-specific extensions, this does not require
+        attribute registration. You cannot write to a group id.
+      operationId: dataAttrRead
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AttributeRaw'
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttributeValueResponseRaw'
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '405':
+          description: Invalid request
+        '500':
+          description: Server-side failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
   
-  /data/subscription:
+  /data/attribute/subscription:
     post:
       tags:
         - data
@@ -786,7 +889,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-
+  
+  /data/attribute/subscription/{id}/{attributename}:
     delete:
       tags:
         - data
@@ -796,12 +900,22 @@ paths:
         Unsubscribe to streaming data from an attribute on a device
       operationId: dataUnsubscribe
       parameters:
-      - name: subscription
-        in: query
-        description: subscription on a device
+      - name: id
+        in: path
+        description: device id that need to be filtered
         required: true
         schema:
-          $ref: '#/components/schemas/Subscription'
+          type: string
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
+      - name: attributename
+        in: path
+        description: attribute name that needs to be filtered
+        required: true
+        explode: true
+        schema:
+          type: string
+          example: "temperature" 
       responses:
         '200':
           description: Success
@@ -821,7 +935,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
-    
+                
     get:
       tags:
         - data
@@ -829,12 +943,22 @@ paths:
       description: Get the status of a subscription on a device
       operationId: dataGetSubscription
       parameters:
-      - name: subscription
-        in: query
-        description: subscription on a device
+      - name: id
+        in: path
+        description: device id that need to be filtered
         required: true
         schema:
-          $ref: '#/components/schemas/Subscription'
+          type: string
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
+      - name: attributename
+        in: path
+        description: attribute name that needs to be filtered
+        required: true
+        explode: true
+        schema:
+          type: string
+          example: "temperature" 
       responses:
         '200':
           description: Success
@@ -855,7 +979,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
-  /data/subscription/topic/{topic}:    
+  /data/attribute/subscription/topic/{topic}:    
     delete:
       tags:
         - data
@@ -927,7 +1051,7 @@ paths:
                 $ref:
                    '#/components/schemas/MultiSubscriptionResponse'
 
-  /data/subscription/id/{id}:
+  /data/attribute/subscription/id/{id}:
     delete:
       tags:
         - data
@@ -998,6 +1122,80 @@ paths:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
+  /data/attribute/subscription/start:
+    post:
+      tags:
+        - data
+      summary: |-
+         Subscribe to streaming data from an attribute on a device
+         by directly addressing hte attribute (unregistered attr)
+      description: |-
+        Subscribe to streaming data from an attribute on a device
+        by directly addressing hte attribute (unregistered attr)
+      operationId: dataSubscriptionStart
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubscriptionRaw'
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'          
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '405':
+          description: Invalid request 
+        '500':
+          description: Server-side failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'  
+  
+  /data/attribute/subscription/stop:
+    post:
+      tags:
+        - data
+      summary: |-
+         Stop streaming data from an attribute on a device
+         by directly addressing hte attribute (unregistered attr)
+      description: |-
+        Stop streaming data from an attribute on a device
+        by directly addressing hte attribute (unregistered attr)
+      operationId: dataSubscriptionStop
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubscriptionRaw'
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'          
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '405':
+          description: Invalid request 
+        '500':
+          description: Server-side failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'  
+ 
   /data/broadcast:
     post:
       tags:
@@ -1102,9 +1300,8 @@ paths:
         - registrations
       summary: unregister a publish/subscribe topic
       description: |-
-        unregister a publish/subscribe topic, Multiple topics can
-        be provided with comma separate strings, or a group id can
-        be provided.
+        unregister a publish/subscribe topic, single topic,
+        multiple topics not allowed.
       operationId: unregisterTopic
       parameters:
         - name: topic
@@ -1121,7 +1318,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MultiTopicsResponse'
+                $ref: '#/components/schemas/TopicResponse'
         '400':
           description: Bad request
         '401':
@@ -1138,11 +1335,10 @@ paths:
     get:
       tags:
         - registrations
-      summary: get one or multiple publish/subscribe topic
+      summary: get one or all publish/subscribe topic
       description: |-
-        unregister a publish/subscribe topic, Multiple topics can be
-        provided with comma separate strings, or a group id can be
-        provided
+        get publish/subscribe topic, if no topic is specified
+        in query, all topics will be returned
       operationId: getTopic
       parameters:
         - name: topic
@@ -1381,6 +1577,214 @@ paths:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
+  /registration/attribute:
+    post:
+      tags:
+        - registrations
+      summary: Register an attribute
+      description: |-
+        Register an attribute for use in data APIs
+      operationId: registerAttribute
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AttributeRegistration'
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttributeRegistrationResponse'
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '405':
+          description: Invalid request
+        '500':
+          description: Server-side failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
+
+    put:
+      tags:
+        - registrations
+      summary: Update an attribute registration
+      description: |-
+        Update an existing attribute registration
+      operationId: updateAttributeRegistration
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AttributeRegistration'
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttributeRegistrationResponse'
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '405':
+          description: Invalid request
+        '500':
+          description: Server-side failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
+
+    delete:
+      tags:
+        - registrations
+      summary: Delete an attribute registration
+      description: Delete an attribute registration
+      operationId: deleteAttributeRegistration
+      parameters:
+        - name: attributename
+          in: query
+          description: attribute name that needs to be filtered
+          required: false
+          explode: true
+          schema:
+            type: string
+            example: "temperature"
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttributeRegistrationResponse'
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '405':
+          description: Invalid request
+        '500':
+          description: Server-side failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
+
+    get:
+      tags:
+        - registrations
+      summary: list registered attributes
+      description: |-
+        get a registered attribute by name of get all 
+        attributes if no names supplied.
+      operationId: getAttributeRegistration
+      parameters:
+        - name: attributename
+          in: query
+          description: attribute name that needs to be filtered
+          required: false
+          explode: true
+          schema:
+            type: string
+            example: "temperature"
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MultiAttributeRegistrationResponse'
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '405':
+          description: Invalid request
+        '500':
+          description: Server-side failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
+
+  /registration/attribute/{attributename}:
+    delete:
+      tags:
+        - registrations
+      summary: delete an attribute registration by name
+      description: delete an attribute registration by name
+      operationId: deleteAttributeRegistrationbyName
+      parameters:
+        - name: attributename
+          in: path
+          description: attribute that needs to be filtered
+          required: true
+          schema:
+            type: string
+            example: "temperature"
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttributeRegistrationResponse'
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '405':
+          description: Invalid request
+        '500':
+          description: Server-side failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
+
+    get:
+      tags:
+        - registrations
+      summary: get an attribute registration by name
+      description: get an attribute registration by name
+      operationId: getAttirbuteRegistrationbyName
+      parameters:
+        - name: attributename
+          in: path
+          description: attribute that needs to be filtered
+          required: true
+          schema:
+            type: string
+            example: "temperature"
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttributeRegistrationResponse'
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '405':
+          description: Invalid request
+        '500':
+          description: Server-side failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
+                
   /registration/file:
     post:
       tags:
@@ -1588,112 +1992,6 @@ paths:
                 $ref: '#/components/schemas/FailureResponse'
 
 ### Extensions
-  /extension/connection/create:
-    post:
-      tags:
-        - extensions
-      summary: |-
-        Connect a device to the network, optionally with service
-        discovery
-      description: |-
-        Connect a device to the network, optionally with service
-        discovery
-      operationId: ExtConnect
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Connection'
-        required: true
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ServiceResponse'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-
-  /extension/connection/delete:
-    post:
-      tags:
-        - extensions
-      summary: |-
-        Connect a device to the network, optionally with service
-        discovery
-      description: |-
-        Connect a device to the network, optionally with service
-        discovery
-      operationId: ExtDisconnect
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Object'
-        required: true
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-
-  /extension/attribute/write:
-    post:
-      tags:
-        - extensions
-      summary: Write a value to an attribute on a device
-      description: Write a value to an attribute on a device
-      operationId: dataAttrWrite
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AttributeValue'
-        required: true
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AttributeValueResponse'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
 
   /extension/attribute/write/file:
     post:
@@ -1751,38 +2049,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-
-  /extension/attribute/read:
-    post:
-      tags:
-        - extensions
-      summary: Read an attribute on a device
-      description: Write a value to an attribute on a device
-      operationId: dataAttrRead
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Attribute'
-        required: true
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
         '400':
           description: Bad request
         '401':
@@ -1877,13 +2143,8 @@ components:
       properties:
         services:
           type: array
-          xml:
-            name: services
-            wrapped: true
           items:
             $ref: '#/components/schemas/BLEService'
-      xml:
-        name: BLEServiceslist
 
 ## A BLE service with its characteristics
     BLEService:
@@ -1898,13 +2159,8 @@ components:
           example: 12345678-1234-5678-1234-56789abcdef4
         characteristics:
           type: array
-          xml:
-            name: characteristics
-            wrapped: true
           items:
             $ref: '#/components/schemas/BLECharacteristic'
-      xml:
-        name: BLEService
 
 ## A BLE characteristics with its descriptors
     BLECharacteristic:
@@ -1931,13 +2187,8 @@ components:
               - notify
         descriptors:
           type: array
-          xml:
-            name: descriptors
-            wrapped: true
           items:
             $ref: '#/components/schemas/BLEDescriptor'
-      xml:
-        name: BLECharacteristic
 
 ## A BLE descriptor
     BLEDescriptor:
@@ -1949,8 +2200,6 @@ components:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      xml:
-        name: BLEDescriptor
 
 ## BLE service ID only
     BLEServiceID:
@@ -1960,8 +2209,6 @@ components:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      xml:
-        name: BLEServiceID
 
 ## Attributes that define a BLE attribute
     BLEAttributes:
@@ -1986,8 +2233,6 @@ components:
             long:
               type: boolean
               example: false
-      xml:
-        name: BLEAttributes
 
 ## Defines different types of BLE topics
     BLETopic:
@@ -2000,8 +2245,6 @@ components:
             - $ref: '#/components/schemas/BLESubTopic'
             - $ref: '#/components/schemas/BLEConnTopic'
             - $ref: '#/components/schemas/BLEAdvTopic'
-      xml:
-        name: BLETopic
 
 ## BLE Gatt Topic definition
     BLESubTopic:
@@ -2022,8 +2265,6 @@ components:
         characteristicID:
           type: string
           example: 12345678-1234-5678-1234-56789abcdef1
-      xml:
-        name: BLESubTopic
 
 ## BLE Connection event Topic definition
     BLEConnTopic:
@@ -2036,8 +2277,6 @@ components:
           example: connection_events
           enum:
             - connection_events
-      xml:
-        name: BLEConnTopic
 
 ## BLE Advertisement Topic definition
     BLEAdvTopic:
@@ -2058,13 +2297,8 @@ components:
             - allow
         filters:
           type: array
-          xml:
-            name: filters
-            wrapped: true
           items:
             $ref: '#/components/schemas/BLEAdvertisement'
-      xml:
-        name: BLEAdvTopic
 
 ## BLE Advertisement attributes
     BLEAdvertisement:
@@ -2078,8 +2312,6 @@ components:
           type: string
           format: byte
           example: 4c00*
-      xml:
-        name: BLEAdvertisement
 
 ## Attributes that define a BLE broadcast
     BLEBroadcast:
@@ -2091,13 +2323,8 @@ components:
           required:
             - advertisement
           type: array
-          xml:
-            name: services
-            wrapped: true
           items:
             $ref: '#/components/schemas/BLEAdvertisement'
-      xml:
-        name: BLEBroadcast
 
 # Zigbee objects
 ## An array for Zigbee Endpoints
@@ -2108,13 +2335,8 @@ components:
       properties:
         endpoints:
           type: array
-          xml:
-            name: endpoints
-            wrapped: true
           items:
             $ref: '#/components/schemas/ZigbeeEndpoint'
-      xml:
-        name: ZigbeeEndpointlist
 
 ## A Zigbee endpoint with its clusters
     ZigbeeEndpoint:
@@ -2129,13 +2351,8 @@ components:
           example: 10
         clusters:
           type: array
-          xml:
-            name: clusters
-            wrapped: true
           items:
             $ref: '#/components/schemas/ZigbeeCluster'
-      xml:
-        name: ZigbeeEndpoint
 
 ## A Zigbee cluster with its attributes
     ZigbeeCluster:
@@ -2150,13 +2367,8 @@ components:
           example: 0
         attributes:
           type: array
-          xml:
-            name: attributes
-            wrapped: true
           items:
             $ref: '#/components/schemas/ZigbeeAttribute'
-      xml:
-        name: ZigbeeCluster
 
 ## A Zigbee attribute
     ZigbeeAttribute:
@@ -2173,8 +2385,6 @@ components:
           type: integer
           format: int32
           example: 32
-      xml:
-        name: ZigbeeAttribute
 
 ## Attributes that define a Zigbee attribute
     ZigbeeAttributes:
@@ -2205,8 +2415,6 @@ components:
               type: integer
               format: int32
               example: 1
-      xml:
-        name: ZigbeeAttributes
 
 ## Attributes that define a Zigbee broadcast
     ZigbeeBroadcast:
@@ -2242,8 +2450,6 @@ components:
               type: integer
               format: int32
               example: 15
-      xml:
-        name: ZigbeeBroadcast
 
 # Common objects
 ## A SCIM object, can be a  device or a group
@@ -2268,8 +2474,6 @@ components:
           enum:
             - ble
             - zigbee
-      xml:
-        name: Object
 
 ## A Service is a device with optional service IDs
     Service:
@@ -2282,9 +2486,6 @@ components:
           properties:
             services:
               type: array
-              xml:
-                name: services
-                wrapped: true
               items:
                 $ref: '#/components/schemas/BLEServiceID'
             cached:
@@ -2302,10 +2503,6 @@ components:
                 autoupdate services if device supports it (default)
               type: boolean
               example: true
-          xml:
-            name: ble
-      xml:
-        name: Service
 
 ## A Connection
     Connection:
@@ -2320,11 +2517,9 @@ components:
         retryMultipleAPs:
           type: boolean
           example: true
-      xml:
-        name: Connection
 
 ## A specific attribute of an Device
-    Attribute:
+    AttributeRaw:
       allOf:
         - $ref: '#/components/schemas/Object'
       oneOf:
@@ -2335,8 +2530,39 @@ components:
         mapping:
           ble: '#/components/schemas/BLEAttributes'
           zigbee: '#/components/schemas/ZigbeeAttributes'
-      xml:
-        name: Attribute
+
+## A value of an attribute of an Device
+    AttributeValueRaw:
+      allOf:
+        - $ref: '#/components/schemas/Attribute'
+      required:
+        - value
+      type: object
+      properties:
+        value:
+          type: string
+          format: byte
+          example: 0001
+        forcedResponse:
+          description: do or do not wait for a response?
+          type: boolean
+          example: true
+        
+## An attribute ID
+    AttributeID:
+      required:
+        - attributeID
+      type: object
+      properties:
+        attributeID:
+          type: string
+          example: "temperature"
+          
+## A specific attribute of an Device
+    Attribute:
+      allOf:
+        - $ref: '#/components/schemas/Object'
+        - $ref: '#/components/schemas/AttributeID'
 
 ## A value of an attribute of an Device
     AttributeValue:
@@ -2354,8 +2580,19 @@ components:
           description: do or do not wait for a response?
           type: boolean
           example: true
-      xml:
-        name: AttributeValue
+          
+## An attribute registration
+    AttributeRegistration:
+      allOf:
+        - $ref: '#/components/schemas/AttributeID'
+      oneOf:
+        - $ref: '#/components/schemas/BLEAttributes'
+        - $ref: '#/components/schemas/ZigbeeAttributes'
+      discriminator:
+        propertyName: technology
+        mapping:
+          ble: '#/components/schemas/BLEAttributes'
+          zigbee: '#/components/schemas/ZigbeeAttributes'
 
 ## A file-based attribute of an Device
     AttributeFile:
@@ -2374,8 +2611,6 @@ components:
           description: do or do not wait for a response?
           type: boolean
           example: true
-      xml:
-        name: AttributeFile
 
 ## A binary blob-based attribute of an Device
     AttributeBlob:
@@ -2394,8 +2629,6 @@ components:
           description: do or do not wait for a response?
           type: boolean
           example: true
-      xml:
-        name: AttributeFile
 
 ## Conditional read of a value (read until specific value is read)
     AttributeConditional:
@@ -2423,40 +2656,33 @@ components:
           description: |-
             time between reads in seconds (default 1, max 60)
           type: integer
-      xml:
-        name: AttributeConditional
 
 ## A subscription attribute of an Device
-    Subscription:
+    SubscriptionRaw:
       allOf:
         - $ref: '#/components/schemas/Attribute'
       type: object
       properties:
-        topic:
-          type: string
-          example: enterprise/hospital/pulse_oximeter
-        dataFormat:
-          description: |-
-            how is information decorated? default: timestamped and
-            attribute ids.
-          type: string
-          example: default
-          enum:
-            - default # decorated with attribute ids
-            - timestamped
-            - payload
-        replay:
-          type: boolean
-          example: false
-          default: false
         forcedAck:
           description: |-
             When not looking at device/attribute support MUST we
             ackhnowledge?
           type: boolean
           example: true
-      xml:
-        name: Subscription
+
+## A specific attribute of an Device
+    Subscription:
+      allOf:
+        - $ref: '#/components/schemas/Object'
+        - $ref: '#/components/schemas/AttributeID'
+      type: object
+      properties:
+        forcedAck:
+          description: |-
+            When not looking at device/attribute support MUST we
+            ackhnowledge?
+          type: boolean
+          example: true
 
 ## A broadcast
     Broadcast:
@@ -2488,8 +2714,6 @@ components:
         broadcastInterval:
           type: integer
           example: 500
-      xml:
-        name: Broadcast
 
 ## Topic Name
     TopicName:
@@ -2500,8 +2724,6 @@ components:
         topic:
           type: string
           example: enterprise/hospital/pulse_oximeter
-      xml:
-        name: TopicName
 
 ## DataStream Topic
     Topic:
@@ -2525,7 +2747,6 @@ components:
           example: default
           enum:
             - default
-            - timestamped
             - payload
         replay:
           type: string
@@ -2533,19 +2754,30 @@ components:
           enum:
             - off #default
             - on
+        id:
+          type: string
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
+        type:
+          type: string
+          example: device
+          enum:
+            - device
+            - group
         dataApps:
           type: array
-          xml:
-            name: dataApps
-            wrapped: true
           items:
             type: object
             properties:
               dataAppID:
                 type: string
                 example: https://data-app-1
-      xml:
-        name: Topic
+        technology:
+          type: string
+          example: ble
+          enum:
+            - ble
+            - zigbee
 
 ## FileName
     FileName:
@@ -2556,23 +2788,35 @@ components:
         filename:
           type: string
           example: "firmware.dat"
-      xml:
-        name: FileName
+
+## FileName
+    FileURL:
+      required:
+        - fileURL
+      type: object
+      properties:
+        fileURL:
+          type: string
+          example: "https://domain.com/firmware.dat"
+          
+## FileName          
+    FileBin:
+      required:
+        - fileBin
+      type: object
+      properties:
+        fileBin:
+          type: string
+          format: binary
+          example: "firmware.dat"
 
 ## File
     File:
       allOf:
         - $ref: '#/components/schemas/FileName'
-      type: object
-      properties:
-        file: #file itself is provided
-          type: string
-          format: binary
-        fileURL: #file can be downloaded from a URL
-          type: string
-          example: "https://domain.com/firmware.dat"
-      xml:
-        name: File
+      oneOf:
+        - $ref: '#/components/schemas/FileURL'
+        - $ref: '#/components/schemas/FileBin'
 
 ## Defines an operation in a bulk API
     Operation:
@@ -2584,37 +2828,53 @@ components:
             operation:
               type: string
               enum:
-               - /extension/connection/create
-               - /extension/connection/delete
-               - /extension/attribute/read
-               - /extension/attribute/write
+               - /connectivity/connection
+               - /data/attribute
+               - /data/attribute/subscription
                - /extension/attribute/write/file
                - /extension/attribute/write/blob
                - /extension/attribute/read/conditional
+            type:  
+              type: string
+              enum:
+               - POST
+               - DELETE
+               - GET
         - oneOf:
-            - $ref: '#/components/schemas/Service'
+            - $ref: '#/components/schemas/Object'
             - $ref: '#/components/schemas/Attribute'
             - $ref: '#/components/schemas/AttributeValue'
             - $ref: '#/components/schemas/AttributeConditional'
             - $ref: '#/components/schemas/AttributeFile'
             - $ref: '#/components/schemas/AttributeBlob'
+            - $ref: '#/components/schemas/Subscription'
           discriminator:
             propertyName: operation
             mapping:
-              /extension/connection/create:
+              POST /connectivity/connection:
                 '#/components/schemas/Service'
-              /extension/attribute/read:
-                '#/components/schemas/Attribute'
-              /extension/attribute/read/conditional:
-                '#/components/schemas/AttributeConditional'
-              /extension/attribute/write:
+              DELETE /connectivity/connection:
+                '#/components/schemas/Object'
+              GET /connectivity/connection:
+                '#/components/schemas/Object'
+              POST /data/attribute:
                 '#/components/schemas/AttributeValue'
-              /extension/attribute/write/file:
+              DELETE /data/attribute:
+                '#/components/schema/Attribute'
+              GET /data/attribute:
+                '#/components/schemas/Attribute'
+              POST /data/attribute/Subscription:
+                '#/components/schemas/Subscription'
+              DELETE /data/attribute/Subscription:
+                '#/components/schemas/Subscription'
+              GET /data/attribute/Subscription:
+                '#/components/schemas/Subscription'
+              POST /extension/attribute/read/conditional:
+                '#/components/schemas/AttributeConditional'
+              POST /extension/attribute/write/file:
                 '#/components/schemas/AttributeFile'
-              /extension/attribute/write/blob:
+              POST /extension/attribute/write/blob:
                 '#/components/schemas/AttributeBlob'
-      xml:
-        name: Operation
 
 ## Bulk schema
     Bulk:
@@ -2630,13 +2890,8 @@ components:
           default: true
         operations:
           type: array
-          xml:
-            name: operations
-            wrapped: true
           items:
             $ref: '#/components/schemas/Operation'
-      xml:
-        name: Bulk
 
 # responses
 ## Baseline success reponse
@@ -2692,8 +2947,6 @@ components:
       oneOf:
         - $ref: '#/components/schemas/SuccessResponse'
         - $ref: '#/components/schemas/FailureResponse'
-      xml:
-        name: Response
 
 ## Success response for binding API
     BindingResponse:
@@ -2701,8 +2954,6 @@ components:
         - $ref: '#/components/schemas/SuccessResponse'
         - $ref: '#/components/schemas/ZigbeeBindingResponse'
         - $ref: '#/components/schemas/FailureResponse'
-      xml:
-        name: BindingeResponse
 
 ## Returning multiple bindings
     MultiBindingsResponse:
@@ -2714,13 +2965,8 @@ components:
       properties:
         bindings:
           type: array
-          xml:
-            name: bindings
-            wrapped: true
           items:
             $ref: '#/components/schemas/BindingResponse'
-      xml:
-        name: MultiBindingsResponse
 
 ## Returns Zigbee node & pan ID
     ZigbeeBindingResponse:
@@ -2736,8 +2982,6 @@ components:
           type: integer
           format: int32
           example: 48734
-      xml:
-        name: ZigbeeBindgingResponse
 
  ## Returns discovered services
     ServiceResponse:
@@ -2746,8 +2990,6 @@ components:
       oneOf:
         - $ref: '#/components/schemas/BLEServiceslist'
         - $ref: '#/components/schemas/ZigbeeEndpointlist'
-      xml:
-        name: ConnectionResponse
 
 ## Response to multiple connections
     MultiConnectionsResponse:
@@ -2759,16 +3001,11 @@ components:
       properties:
         connections:
           type: array
-          xml:
-            name: connections
-            wrapped: true
           items:
             $ref: '#/components/schemas/Response'
-      xml:
-        name: MultiConnectionsResponse
 
 ## Returns an attribute value
-    AttributeValueResponse:
+    AttributeValueResponseRaw:
       allOf:
         - $ref: '#/components/schemas/SuccessResponse'
       required:
@@ -2779,22 +3016,45 @@ components:
           type: string
           example: 01
           format: byte
-      xml:
-        name: AttributeValueResponse
+          
+## Returns an attribute value with ID
+    AttributeValueResponse:
+      allOf:
+        - $ref: '#/components/schemas/SuccessResponse'
+        - $ref: '#/components/schemas/AttributeID'
+      required:
+       - value
+      type: object
+      properties:
+        value:
+          type: string
+          example: 01
+          format: byte
+
+## Returns an attribute registration
+    AttributeRegistrationResponse:
+      allOf:
+        - $ref: '#/components/schemas/Success'
+        - $ref: '#/components/schemas/AttributeRegistration'
+        
+## Returning multiple attribute registrations
+    MultiAttributeRegistrationResponse:
+      allOf:
+        - $ref: '#/components/schemas/Success'
+      required:
+        - attributes
+      type: object
+      properties:
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttributeRegistration'
 
 ## Returns a topic
     TopicResponse:
       allOf:
         - $ref: '#/components/schemas/SuccessResponse'
-      required:
-        - topic
-      type: object
-      properties:
-        topic:
-          type: string
-          example: enterprise/hospital/pulse_oximeter
-      xml:
-        name: TopicResponse
+        - $ref: '#/components/schemas/Topic'
 
 ## Returning multiple topics
     MultiTopicsResponse:
@@ -2806,13 +3066,8 @@ components:
       properties:
         topics:
           type: array
-          xml:
-            name: topics
-            wrapped: true
           items:
-            $ref: '#/components/schemas/TopicName'
-      xml:
-        name: MultiTopicsResponse
+            $ref: '#/components/schemas/Topic'
 
 ## Returning multiple subscriptions
     MultiSubscriptionResponse:
@@ -2824,13 +3079,8 @@ components:
       properties:
         subscriptions:
           type: array
-          xml:
-            name: subscriptions
-            wrapped: true
           items:
             $ref: '#/components/schemas/Subscription'
-      xml:
-        name: MultiSubscriptionResponse
 
 ## Returns a file name
     FileResponse:
@@ -2843,8 +3093,6 @@ components:
         filename:
           type: string
           example: "firmware.dat"
-      xml:
-        name: FileResponse
 
 ## Returning multiple file names
     MultiFileResponse:
@@ -2856,13 +3104,8 @@ components:
       properties:
         filenames:
           type: array
-          xml:
-            name: filenames
-            wrapped: true
           items:
             $ref: '#/components/schemas/FileName'
-      xml:
-        name: MultiFileResponse
 
 ## Multiple returns for a bulk operation
     BulkResponse:
@@ -2872,13 +3115,8 @@ components:
       properties:
         operations:
           type: array
-          xml:
-            name: operations
-            wrapped: true
           items:
             $ref: '#/components/schemas/OperationResponse'
-      xml:
-        name: BulkResponse
 
 ## Return for an operation
     OperationResponse:
@@ -2890,36 +3128,49 @@ components:
             operation:
               type: string
               enum:
-               - /connectivity/connection/create
-               - /connectivity/connection/delete
-               - /extension/attribute/read
-               - /extension/attribute/write
+               - /connectivity/connection
+               - /data/attribute
+               - /data/attribute/subscription
                - /extension/attribute/write/file
                - /extension/attribute/write/blob
                - /extension/attribute/read/conditional
+            type:  
+              type: string
+              enum:
+               - POST
+               - DELETE
+               - GET
         - oneOf:
-          - $ref: '#/components/schemas/ServiceResponse'
-          - $ref: '#/components/schemas/SuccessResponse'
-          - $ref: '#/components/schemas/AttributeValueResponse'
+            - $ref: '#/components/schemas/SuccessResponse'
+            - $ref: '#/components/schemas/ServiceResponse'
+            - $ref: '#/components/schemas/AttributeValueResponse'
           discriminator:
             propertyName: operation
             mapping:
-              /connectivity/connection/create:
+              POST /connectivity/connection:
                 '#/components/schemas/ServiceResponse'
-              /connectivity/connection/delete:
+              DELETE /connectivity/connection:
                 '#/components/schemas/SuccessResponse'
-              /extension/attribute/read:
-                '#/components/schemas/AttributeValueResponse'
-              /extension/attribute/write:
-                '#/components/schemas/AttributeValueResponse'
-              /extension/attribute/write/file:
+              GET /connectivity/connection:
                 '#/components/schemas/SuccessResponse'
-              /extension/attribute/write/blob:
-                '#/components/schemas/SuccessResponse'
-              /extension/attribute/read/conditional:
+              POST /data/attribute:
+                '#/components/schemas/RegisteredAttributeValue'
+              DELETE /data/attribute:
                 '#/components/schemas/AttributeValueResponse'
-      xml:
-        name: Operation
+              GET /data/attribute:
+                '#/components/schemas/AttributeValueResponse'
+              POST /data/attribute/Subscription:
+                '#/components/schemas/SuccessResponse'
+              DELETE /data/attribute/Subscription:
+                '#/components/schemas/SuccessResponse'
+              GET /data/attribute/Subscription:
+                '#/components/schemas/SuccessResponse'
+              POST /extension/attribute/read/conditional:
+                '#/components/schemas/AttributeValueResponse'
+              POST /extension/attribute/write/file:
+                '#/components/schemas/SuccessResponse'
+              POST /extension/attribute/write/blob:
+                '#/components/schemas/SuccessResponse'
 
  # API key authorization
   securitySchemes:

--- a/nipc-openapi/NIPC_REST.yaml
+++ b/nipc-openapi/NIPC_REST.yaml
@@ -108,7 +108,7 @@ paths:
             items:
               type: string
               format: uuid
-            example: 12345678-1234-5678-1234-56789abcdef4
+              example: 12345678-1234-5678-1234-56789abcdef4
       responses:
         '200':
           description: Success
@@ -146,9 +146,11 @@ paths:
           required: false
           explode: false
           schema:
-            type: string
-            format: uuid
-            example: 12345678-1234-5678-1234-56789abcdef4
+            type: array
+            items:
+              type: string
+              format: uuid
+              example: 12345678-1234-5678-1234-56789abcdef4
       responses:
         '200':
           description: Success
@@ -340,9 +342,11 @@ paths:
           required: false
           explode: false
           schema:
-            type: string
-            format: uuid
-            example: 12345678-1234-5678-1234-56789abcdef4
+            type: array
+            items:
+              type: string
+              format: uuid
+              example: 12345678-1234-5678-1234-56789abcdef4
       responses:
         '200':
           description: Success
@@ -379,9 +383,11 @@ paths:
           required: false
           explode: false
           schema:
-            type: string
-            format: uuid
-            example: 12345678-1234-5678-1234-56789abcdef4
+            type: array
+            items:
+              type: string
+              format: uuid
+              example: 12345678-1234-5678-1234-56789abcdef4
       responses:
         '200':
           description: Success
@@ -2307,7 +2313,7 @@ components:
     BLEAdvertisement:
       type: object
       properties:
-        adTtype:
+        adType:
           type: string
           format: byte
           example: ff
@@ -2537,7 +2543,7 @@ components:
 ## A value of an attribute of an Device
     AttributeValueRaw:
       allOf:
-        - $ref: '#/components/schemas/Attribute'
+        - $ref: '#/components/schemas/AttributeRaw'
       required:
         - value
       type: object

--- a/nipc-openapi/NIPC_REST.yaml
+++ b/nipc-openapi/NIPC_REST.yaml
@@ -2750,11 +2750,9 @@ components:
             - default
             - payload
         replay:
-          type: string
-          example: off
-          enum:
-            - off #default
-            - on
+          type: boolean
+          example: false
+          default: false
         id:
           type: string
           format: uuid

--- a/nipc-openapi/NIPC_REST.yaml
+++ b/nipc-openapi/NIPC_REST.yaml
@@ -28,7 +28,7 @@ info:
   license:
     name: TBD
     url: TBD
-  version: 0.5.3
+  version: 0.5.5
 externalDocs:
   description: NIPC IETF draft
   url: TBD
@@ -67,12 +67,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Object'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/Object'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Object'
         required: true
       responses:
         '200':
@@ -81,9 +75,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BindingResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/BindingResponse'
         '400':
           description: Bad request
         '401':
@@ -96,9 +87,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
   
     get:
       tags:
@@ -126,9 +114,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiBindingsResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/MultiBindingsResponse'
         '400':
           description: Bad request
         '401':
@@ -141,9 +126,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'                
+                
     delete:
       tags:
         - connectivity
@@ -171,9 +154,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
         '400':
           description: Bad request
         '401':
@@ -186,9 +166,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
   
   /connectivity/binding/id/{id}:
     post:
@@ -217,9 +194,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BindingResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/BindingResponse'
+
         '400':
           description: Bad request
         '401':
@@ -232,9 +207,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
   
     get:
       tags:
@@ -260,9 +232,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BindingResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/BindingResponse'
+
         '400':
           description: Bad request
         '401':
@@ -275,9 +245,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
                 
     delete:
       tags:
@@ -301,9 +268,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
         '400':
           description: Bad request
         '401':
@@ -316,9 +280,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
   
   /connectivity/connection:
     post:
@@ -336,12 +297,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Connection'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/Connection'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Connection'
         required: true
       responses:
         '200':
@@ -350,9 +305,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/ServiceResponse'
         '400':
           description: Bad request
         '401':
@@ -365,9 +317,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
     
     get:
       tags:
@@ -398,9 +347,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiConnectionsResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/MultiConnectionsResponse'
         '400':
           description: Bad request
         '401':
@@ -413,9 +359,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
                 
     delete:
       tags:
@@ -443,9 +386,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
         '400':
           description: Bad request
         '401':
@@ -458,9 +398,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
 
   /connectivity/connection/id/{id}:
     post:
@@ -490,9 +427,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
         '400':
           description: Bad request
         '401':
@@ -505,9 +439,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
   
     get:
       tags:
@@ -533,9 +464,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
         '400':
           description: Bad request
         '401':
@@ -548,9 +476,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
                 
     delete:
       tags:
@@ -574,9 +499,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
         '400':
           description: Bad request
         '401':
@@ -589,9 +511,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
   
   /connectivity/services:
     get:
@@ -614,9 +533,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/ServiceResponse'
         '400':
           description: Bad request
         '401':
@@ -655,9 +571,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/ServiceResponse'
         '400':
           description: Bad request
         '401':
@@ -670,9 +583,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
 
 ### Data
   /data/attribute:
@@ -687,12 +597,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AttributeValue'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/AttributeValue'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AttributeValue'
         required: true
       responses:
         '200':
@@ -701,9 +605,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AttributeValueResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/AttributeValueResponse'
         '400':
           description: Bad request
         '401':
@@ -716,9 +617,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
     
     put:
       tags:
@@ -731,21 +629,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AttributeValue'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/AttributeValue'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AttributeValue'
         required: true
       responses:
         '200':
           description: Success
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/AttributeValueResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/AttributeValueResponse'
         '400':
@@ -760,9 +649,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
   
     delete:
       tags:
@@ -784,9 +670,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AttributeValueResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/AttributeValueResponse'
         '400':
           description: Bad request
         '401':
@@ -799,9 +682,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
                 
     get:
       tags:
@@ -823,9 +703,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AttributeValueResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/AttributeValueResponse'
         '400':
           description: Bad request
         '401':
@@ -838,9 +715,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
   
   /data/subscription:
     post:
@@ -856,12 +730,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Subscription'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/Subscription'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Subscription'
         required: true
       responses:
         '200':
@@ -870,9 +738,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
         '400':
           description: Bad request
         '401':
@@ -885,9 +750,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse'   
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
                 
     put:
       tags:
@@ -904,12 +766,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Subscription'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/Subscription'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Subscription'
         required: true
       responses:
         '200':
@@ -918,9 +774,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
         '400':
           description: Bad request
         '401':
@@ -933,9 +786,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FailureResponse' 
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
 
     delete:
       tags:
@@ -959,9 +809,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
         '400':
           description: Bad request
         '401':
@@ -972,9 +819,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
     
@@ -998,9 +842,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'          
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
         '400':
           description: Bad request
         '401':
@@ -1011,9 +852,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1040,10 +878,6 @@ paths:
               schema:
                 $ref:
                    '#/components/schemas/MultiSubscriptionResponse'
-            application/xml:
-              schema:
-                $ref:
-                   '#/components/schemas/MultiSubscriptionResponse'
         '400':
           description: Bad request
         '401':
@@ -1054,9 +888,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1082,10 +913,6 @@ paths:
               schema:
                 $ref:
                    '#/components/schemas/MultiSubscriptionResponse'
-            application/xml:
-              schema:
-                $ref:
-                   '#/components/schemas/MultiSubscriptionResponse'
         '400':
           description: Bad request
         '401':
@@ -1096,10 +923,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref:
-                   '#/components/schemas/MultiSubscriptionResponse'
-            application/xml:
               schema:
                 $ref:
                    '#/components/schemas/MultiSubscriptionResponse'
@@ -1127,10 +950,6 @@ paths:
               schema:
                 $ref:
                    '#/components/schemas/MultiSubscriptionResponse'
-            application/xml:
-              schema:
-                $ref:
-                   '#/components/schemas/MultiSubscriptionResponse'
         '400':
           description: Bad request
         '401':
@@ -1141,9 +960,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1169,10 +985,6 @@ paths:
               schema:
                 $ref:
                    '#/components/schemas/MultiSubscriptionResponse'
-            application/xml:
-              schema:
-                $ref:
-                   '#/components/schemas/MultiSubscriptionResponse'
         '400':
           description: Bad request
         '401':
@@ -1183,9 +995,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1201,21 +1010,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Broadcast'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/Broadcast'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Broadcast'
         required: true
       responses:
         '200':
           description: Success
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
         '400':
@@ -1228,9 +1028,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1247,21 +1044,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Topic'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/Topic'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Topic'
         required: true
       responses:
         '200':
           description: Success
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/TopicResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/TopicResponse'
         '400':
@@ -1274,9 +1062,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1291,21 +1076,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Topic'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/Topic'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Topic'
         required: true
       responses:
         '200':
           description: Success
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/TopicResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/TopicResponse'
         '400':
@@ -1318,9 +1094,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1349,9 +1122,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiTopicsResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/MultiTopicsResponse'
         '400':
           description: Bad request
         '401':
@@ -1362,9 +1132,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1393,9 +1160,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiTopicsResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/MultiTopicsResponse'
         '400':
           description: Bad request
         '401':
@@ -1406,9 +1170,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1434,9 +1195,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TopicResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/TopicResponse'
         '400':
           description: Bad request
         '401':
@@ -1447,9 +1205,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1474,9 +1229,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TopicResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/TopicResponse'
         '400':
           description: Bad request
         '401':
@@ -1487,9 +1239,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1516,9 +1265,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiTopicsResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/MultiTopicsResponse'
         '400':
           description: Bad request
         '401':
@@ -1529,9 +1275,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1556,9 +1299,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiTopicsResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/MultiTopicsResponse'
         '400':
           description: Bad request
         '401':
@@ -1569,9 +1309,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1597,9 +1334,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiTopicsResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/MultiTopicsResponse'
         '400':
           description: Bad request
         '401':
@@ -1610,9 +1344,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1637,9 +1368,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiTopicsResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/MultiTopicsResponse'
         '400':
           description: Bad request
         '401':
@@ -1650,9 +1378,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1668,21 +1393,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/File'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/File'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/File'
         required: true
       responses:
         '200':
           description: Success
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
         '400':
@@ -1695,9 +1411,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1712,21 +1425,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/File'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/File'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/File'
         required: true
       responses:
         '200':
           description: Success
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
         '400':
@@ -1739,9 +1443,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1767,9 +1468,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
         '400':
           description: Bad request
         '401':
@@ -1780,9 +1478,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1810,9 +1505,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiFileResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/MultiFileResponse'
         '400':
           description: Bad request
         '401':
@@ -1823,9 +1515,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1851,9 +1540,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FileResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FileResponse'
         '400':
           description: Bad request
         '401':
@@ -1864,9 +1550,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1891,9 +1574,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FileResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/FileResponse'
         '400':
           description: Bad request
         '401':
@@ -1904,9 +1584,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1927,21 +1604,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Connection'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/Connection'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Connection'
         required: true
       responses:
         '200':
           description: Success
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/ServiceResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/ServiceResponse'
         '400':
@@ -1954,9 +1622,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -1976,21 +1641,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Object'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/Object'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Object'
         required: true
       responses:
         '200':
           description: Success
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
         '400':
@@ -2003,9 +1659,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -2021,21 +1674,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AttributeValue'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/AttributeValue'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AttributeValue'
         required: true
       responses:
         '200':
           description: Success
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/AttributeValueResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/AttributeValueResponse'
         '400':
@@ -2048,9 +1692,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -2067,21 +1708,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AttributeFile'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/AttributeFile'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AttributeFile'
         required: true
       responses:
         '200':
           description: Success
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
         '400':
@@ -2094,9 +1726,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -2114,21 +1743,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AttributeBlob'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/AttributeBlob'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AttributeBlob'
         required: true
       responses:
         '200':
           description: Success
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
         '400':
@@ -2141,9 +1761,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -2159,12 +1776,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Attribute'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/Attribute'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Attribute'
         required: true
       responses:
         '200':
@@ -2172,10 +1783,6 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AttributeValueResponse'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/AttributeValueResponse'
         '400':
           description: Bad request
         '401':
@@ -2186,9 +1793,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -2208,21 +1812,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AttributeConditional'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/AttributeConditional'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AttributeConditional'
         required: true
       responses:
         '200':
           description: Success
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/AttributeValueResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/AttributeValueResponse'
         '400':
@@ -2235,9 +1830,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
@@ -2253,21 +1845,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Bulk'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/Bulk'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Bulk'
         required: true
       responses:
         '200':
           description: Success
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/BulkResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/BulkResponse'
         '400':
@@ -2280,9 +1863,6 @@ paths:
           description: Server-side failure
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-            application/xml:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 

--- a/nipc-openapi/NIPC_REST.yaml
+++ b/nipc-openapi/NIPC_REST.yaml
@@ -104,8 +104,10 @@ paths:
           required: false
           explode: false
           schema:
-            type: string
-            format: uuid
+            type: array
+            items:
+              type: string
+              format: uuid
             example: 12345678-1234-5678-1234-56789abcdef4
       responses:
         '200':

--- a/nipc-openapi/NIPC_REST.yaml
+++ b/nipc-openapi/NIPC_REST.yaml
@@ -2835,7 +2835,7 @@ components:
                - /extension/attribute/write/file
                - /extension/attribute/write/blob
                - /extension/attribute/read/conditional
-            type:  
+            method:  
               type: string
               enum:
                - POST


### PR DESCRIPTION
NIPC open-api changes:
- take xml out of the openapi def
- add id (device our group) to register topic (optional for advertisement, mandatory for gatt and conn_events)
- looks multi-attribute at comma separated parameters as a whole, and remove where confusing
- remove group id description in get topic
- get topic supports get all without parameter
- include full topic in topic response
- Add attribute registration
- Update /data/attribute POST/PUT to use a registered attribute
- new GET/DELETE methods leveraging id and attribute in the path
- Move POST /data/attribute/read and write to /data to be used as direct read/write without attribute registration
- Move subscription under /data/attribute and adopt registered attribute approach for all subscription API’s
- Create POST /data/subscription/start & stop for direct subscription without attribute registration
- File is oneOf URL or binary
- reworked bulk API, to support POST / GET / DELETE and attribute registration based approach