### PR TITLE
Updated broadcast API to send base64 string of the raw binary advertisement

### DIFF
--- a/nipc-openapi/NIPC_REST.yaml
+++ b/nipc-openapi/NIPC_REST.yaml
@@ -1971,11 +1971,9 @@ components:
       properties:
         adType:
           type: string
-          format: byte
           example: ff
         adData:
           type: string
-          format: byte
           example: 4c00*
 
 ## Properties that define a BLE broadcast
@@ -1990,9 +1988,9 @@ components:
             - advertisement
           properties:
             advertisement:
-              type: array
-              items:
-                $ref: '#/components/schemas/BLEAdvertisement'
+              type: string
+              format: byte
+              example: AgEaAgoMFv9MABAHch9BsDkgeA==
 
 # Zigbee objects
 ## An array for Zigbee Endpoints


### PR DESCRIPTION
The BLEAdvertisment schema will only be used for adv filtering and consists of patterns